### PR TITLE
fixed eol for cross OS requests

### DIFF
--- a/src/QueryParser/JSONParser.php
+++ b/src/QueryParser/JSONParser.php
@@ -54,7 +54,7 @@ abstract class JSONParser extends BaseParser implements JSONParserInterface {
 	 */
 	public static function parseNdJSON($query): Iterable {
 		do {
-			$eolPos = strpos($query, PHP_EOL);
+			$eolPos = strpos($query, "\n");
 			if ($eolPos === false) {
 				$eolPos = strlen($query);
 			}


### PR DESCRIPTION
When Logstash runs at the Linux or docker container but daemon works at Windows `$eolPos = strpos($query, PHP_EOL);` returns `false` due to `PHP_EOL` sets to Windows type of end of line but Logstash sends request from Linux with Linux end of line.

I suggest to use `\n` that works for this case well.